### PR TITLE
Fixes #107: Allow frames after RST_STREAM.

### DIFF
--- a/lib/protocol/stream.js
+++ b/lib/protocol/stream.js
@@ -567,6 +567,7 @@ Stream.prototype._transition = function transition(sending, frame) {
     //   can be used to close any of those streams.
     case 'CLOSED':
       if (PRIORITY || (sending && RST_STREAM) ||
+          (sending && this._closedWithRst) ||
           (receiving && WINDOW_UPDATE) ||
           (receiving && this._closedByUs &&
            (this._closedWithRst || RST_STREAM || ALTSVC))) {


### PR DESCRIPTION
Prevent exceptions for the common case in which the serving endpoint
sends frames after the RST_STREAM has been sent from the client
endpoint. Often frames are enqueued prior to the arrival of the
RST_STREAM, but sent after. This should be expected based on HTTP/2
spec, section 6.4.

https://http2.github.io/http2-spec/#rfc.section.6.4

"However, after sending the RST_STREAM, the sending endpoint MUST be
prepared to receive and process additional frames sent on the stream
that might have been sent by the peer prior to the arrival of the
RST_STREAM."